### PR TITLE
Build ES5 module-by-module to `/lib`

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,5 @@
 {
-  "presets": ["@babel/env"]
+  "presets": [
+    ["@babel/env", { targets: { node: "6" }, modules: "cjs" }]
+  ]
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1025,11 +1025,6 @@
          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
          "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo="
       },
-      "amdefine": {
-         "version": "1.0.1",
-         "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-         "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
-      },
       "ansi-colors": {
          "version": "2.0.5",
          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-2.0.5.tgz",
@@ -2484,23 +2479,20 @@
          }
       },
       "css": {
-         "version": "2.2.3",
-         "resolved": "https://registry.npmjs.org/css/-/css-2.2.3.tgz",
-         "integrity": "sha512-0W171WccAjQGGTKLhw4m2nnl0zPHUlTO/I8td4XzJgIB8Hg3ZZx71qT4G4eX8OVsSiaAKiUMy73E3nsbPlg2DQ==",
+         "version": "2.2.4",
+         "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
+         "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
          "requires": {
-            "inherits": "^2.0.1",
-            "source-map": "^0.1.38",
-            "source-map-resolve": "^0.5.1",
+            "inherits": "^2.0.3",
+            "source-map": "^0.6.1",
+            "source-map-resolve": "^0.5.2",
             "urix": "^0.1.0"
          },
          "dependencies": {
             "source-map": {
-               "version": "0.1.43",
-               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-               "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-               "requires": {
-                  "amdefine": ">=0.0.4"
-               }
+               "version": "0.6.1",
+               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+               "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
             }
          }
       },
@@ -2546,12 +2538,17 @@
          },
          "dependencies": {
             "debug": {
-               "version": "3.1.0",
-               "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-               "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+               "version": "3.2.6",
+               "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+               "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
                "requires": {
-                  "ms": "2.0.0"
+                  "ms": "^2.1.1"
                }
+            },
+            "ms": {
+               "version": "2.1.1",
+               "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+               "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
             }
          }
       },
@@ -5060,6 +5057,24 @@
                "requires": {
                   "camelcase": "^3.0.0"
                }
+            }
+         }
+      },
+      "gulp-babel": {
+         "version": "8.0.0",
+         "resolved": "https://registry.npmjs.org/gulp-babel/-/gulp-babel-8.0.0.tgz",
+         "integrity": "sha512-oomaIqDXxFkg7lbpBou/gnUkX51/Y/M2ZfSjL2hdqXTAlSWZcgZtd2o0cOH0r/eE8LWD0+Q/PsLsr2DKOoqToQ==",
+         "requires": {
+            "plugin-error": "^1.0.1",
+            "replace-ext": "^1.0.0",
+            "through2": "^2.0.0",
+            "vinyl-sourcemaps-apply": "^0.2.0"
+         },
+         "dependencies": {
+            "replace-ext": {
+               "version": "1.0.0",
+               "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+               "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
             }
          }
       },
@@ -9213,11 +9228,11 @@
          }
       },
       "timers-ext": {
-         "version": "0.1.5",
-         "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.5.tgz",
-         "integrity": "sha512-tsEStd7kmACHENhsUPaxb8Jf8/+GZZxyNFQbZD07HQOyooOa6At1rQqjffgvg7n+dxscQa9cjjMdWhJtsP2sxg==",
+         "version": "0.1.7",
+         "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
+         "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
          "requires": {
-            "es5-ext": "~0.10.14",
+            "es5-ext": "~0.10.46",
             "next-tick": "1"
          }
       },

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
       "camelcase": "^5.0.0",
       "chai": "^4.2.0",
       "del": "^3.0.0",
+      "gulp-babel": "^8.0.0",
       "gulp-connect": "^5.5.0",
       "gulp-eslint": "^5.0.0",
       "gulp-filter": "^5.1.0",

--- a/src/config.json
+++ b/src/config.json
@@ -1,6 +1,7 @@
 {
   "directories": {
-    "lib": "src",
+    "src": "src",
+    "es5": "lib",
     "dist": "dist",
     "test": "test",
     "tmp": "tmp"

--- a/src/config.json
+++ b/src/config.json
@@ -8,7 +8,7 @@
   },
   "config": {
     "build": {
-      "transpileGlob": "**/*.{js,jsx,ts,tsx}",
+      "transpileGlobs": ["**/*.{js,jsx,ts,tsx}"],
       "libraryName": null,
       "libraryTarget": "umd",
       "libraryExport": "default",

--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
   },
   "config": {
     "build": {
+      "transpileGlob": "**/*.{js,jsx,ts,tsx}",
       "libraryName": null,
       "libraryTarget": "umd",
       "libraryExport": "default",

--- a/src/tasks/build-dist.js
+++ b/src/tasks/build-dist.js
@@ -14,12 +14,6 @@ import {logError, error} from '../utility';
 export default function(gulp, pkg) {
   const { directories: dirs, config } = pkg;
 
-  // Deprecating `dirs.lib`, in favour of the unambiguous `dirs.src`/`dirs.es5`.
-  if (null != dirs.lib) {
-    console.warn('@codeverse/gulp-registry: Using directories.lib is deprecated; please provide .src and .es5 instead.');
-    dirs.src = dirs.lib;
-  }
-
   // Configure defaults based on the usual contents of `package.json`
   const shortPkgName = parsePackageJsonName(pkg.name).fullName
       , libraryName = config.build.libraryName || camelCase(shortPkgName, {pascalCase: true});

--- a/src/tasks/build-lib.js
+++ b/src/tasks/build-lib.js
@@ -5,7 +5,7 @@ import sourcemaps from 'gulp-sourcemaps';
 export default function(gulp, pkg) {
   const { directories: dirs, config } = pkg;
 
-  const inputs = `${dirs.src}/${config.build.transpileGlob}`;
+  const inputs = config.build.transpileGlobs.map(g => `${dirs.src}/${g}`);
 
   // choose the destination folder
   const destinationFolder = dirs.es5;

--- a/src/tasks/build-lib.js
+++ b/src/tasks/build-lib.js
@@ -1,0 +1,18 @@
+import path from 'path';
+import babel from 'gulp-babel';
+import sourcemaps from 'gulp-sourcemaps';
+
+export default function(gulp, pkg) {
+  const { directories: dirs, config } = pkg;
+
+  const inputs = `${dirs.src}/${config.build.transpileGlob}`;
+
+  // choose the destination folder
+  const destinationFolder = dirs.es5;
+
+  return gulp.src(inputs, { matchBase: true })
+    .pipe(sourcemaps.init({ loadMaps: true }))
+      .pipe(babel())
+    .pipe(sourcemaps.write('.'))
+    .pipe(gulp.dest(destinationFolder));
+}

--- a/src/tasks/build.js
+++ b/src/tasks/build.js
@@ -14,6 +14,12 @@ import {logError, error} from '../utility';
 export default function(gulp, pkg) {
   const { directories: dirs, config } = pkg;
 
+  // Deprecating `dirs.lib`, in favour of the unambiguous `dirs.src`/`dirs.es5`.
+  if (null != dirs.lib) {
+    console.warn('@codeverse/gulp-registry: Using directories.lib is deprecated; please provide .src and .es5 instead.');
+    dirs.src = dirs.lib;
+  }
+
   // Configure defaults based on the usual contents of `package.json`
   const shortPkgName = parsePackageJsonName(pkg.name).fullName
       , libraryName = config.build.libraryName || camelCase(shortPkgName, {pascalCase: true});
@@ -30,7 +36,7 @@ export default function(gulp, pkg) {
 
   // determine the initial source file
   const sourceEntryPath = config.build.entryFile
-    ? path.join(dirs.lib, config.build.entryFile)
+    ? path.join(dirs.src, config.build.entryFile)
     : pkg.main;
 
   const sourceEntryFilename = path.basename(sourceEntryPath);

--- a/src/tasks/build.js
+++ b/src/tasks/build.js
@@ -34,10 +34,12 @@ export default function(gulp, pkg) {
   // choose the destination folder
   const destinationFolder = dirs.dist;
 
-  // determine the initial source file
-  const sourceEntryPath = config.build.entryFile
+  // If not configured, we default to entering at the package's "main" file. If present, this will
+  // be the ES6-module file under "module", preferentially. See:
+  //   <https://github.com/dherman/defense-of-dot-js/blob/master/proposal.md#typical-usage>
+  const sourceEntryPath = null != config.build.entryFile
     ? path.join(dirs.src, config.build.entryFile)
-    : pkg.main;
+    : (null != pkg.module ? pkg.module : pkg.main);
 
   const sourceEntryFilename = path.basename(sourceEntryPath);
 

--- a/src/tasks/test-browser.js
+++ b/src/tasks/test-browser.js
@@ -4,7 +4,7 @@ import connect from 'gulp-connect';
 import livereload from 'gulp-livereload';
 import webpackStream from 'webpack-stream';
 
-import buildTask from './build.js';
+import buildTask from './build-dist.js';
 
 
 // default task

--- a/src/tasks/test.js
+++ b/src/tasks/test.js
@@ -96,10 +96,12 @@ export default function(gulp, pkg) {
   // choose the destination folder
   const destinationFolder = dirs.dist;
 
-  // determine the initial source file
-  const sourceEntryPath = config.build.entryFile
+  // If not configured, we default to entering at the package's "main" file. If present, this will
+  // be the ES6-module file under "module", preferentially. See:
+  //   <https://github.com/dherman/defense-of-dot-js/blob/master/proposal.md#typical-usage>
+  const sourceEntryPath = null != config.build.entryFile
     ? path.join(dirs.src, config.build.entryFile)
-    : pkg.main;
+    : (null != pkg.module ? pkg.module : pkg.main);
 
   const sourceEntryFilename = path.basename(sourceEntryPath);
 

--- a/src/tasks/test.js
+++ b/src/tasks/test.js
@@ -77,6 +77,11 @@ function invokeMochaWebpack(configOptions = {}) {
 export default function(gulp, pkg) {
   const { directories: dirs, config } = pkg;
 
+  if (null != dirs.lib) {
+    console.warn('@codeverse/gulp-registry: Using directories.lib is deprecated; please provide .src and .es5 instead.');
+    dirs.src = dirs.lib;
+  }
+
   // Configure defaults based on the usual contents of `package.json`
   const shortPkgName = parsePackageJsonName(pkg.name).fullName
       , libraryName = config.build.libraryName || camelCase(shortPkgName, {pascalCase: true});
@@ -93,7 +98,7 @@ export default function(gulp, pkg) {
 
   // determine the initial source file
   const sourceEntryPath = config.build.entryFile
-    ? path.join(dirs.lib, config.build.entryFile)
+    ? path.join(dirs.src, config.build.entryFile)
     : pkg.main;
 
   const sourceEntryFilename = path.basename(sourceEntryPath);

--- a/src/tasks/watch.js
+++ b/src/tasks/watch.js
@@ -4,7 +4,7 @@ export default function watch(gulp, pkg) {
 
   // files to watch
   const watchFiles = [
-    `./${dirs.lib }/**/*`,
+    `./${dirs.src }/**/*`,
     `./${dirs.test}/**/*`,
   ];
 


### PR DESCRIPTION
At the moment, for expediency, I only shipped two forms of compilation products with our modules:

1. `/dist/lib-name.{yaddayadda}.js`, a UMD-build for direct inclusion by web browsers and for easy testing in manual HTML test-files; (we currently build the IDE off of this. We shouldn't be building the IDE off of this.)
2. `/src/**/*.{js,jsx,ts,re,ml,…}`, the original, untranspiled sources. (The conventions here can, and should, vary by project. Babel configuration, presence or absence of TypeScript, Reason, Elm … these are things a library-consumer shouldn't be concerned with.)

In this PR, I add the third, much-more-standard entry-point:

3. `/lib/**/*.js`, a mapping of each `/src` file, directly transpiled down to a lowest-common-denominator ES5 target. Unlike №1, this doesn't introduce any conflicting globals — module resolution and bundling are still up to the consumer. Unlike №2, though, these files require no agreement between the library being built and the library-consumer regarding resolution, bundling, or JavaScript capabilities (to an extent, at least.)

(TypeScript typedefs will also eventually be emitted to this directory, for loose typing-interoperability between projects.)

Some effort is / will be made to maintain sourcemaps thru multiple tools.

Each project's `src/entrypoint.js` should be converted to `lib/entrypoint.js` in the `package.json`'s `"main"` field for semantic reasons; but I don't believe any of our tooling actually *consumes* that yet. Additionally, `"directories.lib"` will emit a deprecation warning, if an old version of one of our packages happens to get upgraded accidentally to newer tooling.

This should be a backwards-compatible change.